### PR TITLE
Fix decimal input validation for all calculators.

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -137,10 +137,6 @@ document.addEventListener('DOMContentLoaded', () => {
         input.value = value;
     }
 
-    billAmountInput.addEventListener('input', validateDecimalInput);
-    totalBillInput.addEventListener('input', validateDecimalInput);
-    originalPriceInput.addEventListener('input', validateDecimalInput);
-
     // --- Navigation ---
     function showTipCalculator() {
         tipCalculatorSection.classList.remove('hidden');
@@ -199,12 +195,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     billAmountInput.addEventListener('input', (e) => {
-        e.target.value = e.target.value.replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1');
+        validateDecimalInput(e);
         calculateTip();
     });
 
     customTipInput.addEventListener('input', (e) => {
-        e.target.value = e.target.value.replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1');
+        validateDecimalInput(e);
         if (activeTipBtn) {
             activeTipBtn.classList.remove('active');
             activeTipBtn = null;
@@ -252,12 +248,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     totalBillInput.addEventListener('input', (e) => {
-        e.target.value = e.target.value.replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1');
+        validateDecimalInput(e);
         calculateBillSplit();
     });
 
     tipPercentageSplitInput.addEventListener('input', (e) => {
-        e.target.value = e.target.value.replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1');
+        validateDecimalInput(e);
         calculateBillSplit();
     });
 
@@ -287,12 +283,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     originalPriceInput.addEventListener('input', (e) => {
-        e.target.value = e.target.value.replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1');
+        validateDecimalInput(e);
         calculateDiscount();
     });
 
     discountPercentageInput.addEventListener('input', (e) => {
-        e.target.value = e.target.value.replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1');
+        validateDecimalInput(e);
         calculateDiscount();
     });
 

--- a/tests/bug_repro.js
+++ b/tests/bug_repro.js
@@ -1,0 +1,57 @@
+/**
+ * To run this test:
+ * 1. Open the index.html file in a web browser.
+ * 2. Open the browser's developer console.
+ * 3. Copy and paste the content of this file into the console and press Enter.
+ * 4. The test function `runValidationTest()` will be executed.
+ * 5. Observe the console output for the test result.
+ *
+ * This test checks the validation logic for the 'Bill Amount' input field.
+ * It simulates a user typing "12.3.4" into the field.
+ *
+ * The expected (but incorrect) behavior before the fix is that the input's value
+ * will be truncated to "12.3". The test will pass if this happens.
+ *
+ * After the fix, the validation should correctly change the value to "12.34",
+ * and therefore this test will fail, indicating the bug has been resolved.
+ */
+function runValidationTest() {
+    console.log("--- Running Bug Reproduction Test ---");
+
+    // 1. Get the input element to test
+    const billAmountInput = document.getElementById('billAmount');
+    if (!billAmountInput) {
+        console.error("Test failed: Could not find the 'billAmount' input element.");
+        return;
+    }
+
+    // 2. Set a value with multiple decimal points
+    billAmountInput.value = "12.3.4";
+    console.log(`Set input value to: "${billAmountInput.value}"`);
+
+    // 3. Dispatch an 'input' event to trigger the validation logic
+    const inputEvent = new Event('input', { bubbles: true });
+    billAmountInput.dispatchEvent(inputEvent);
+    console.log("Dispatched 'input' event.");
+
+    // 4. Check the resulting value
+    const finalValue = billAmountInput.value;
+    console.log(`Final input value is: "${finalValue}"`);
+
+    // 5. Assert the incorrect behavior
+    const expectedValueBeforeFix = "12.3";
+    console.assert(
+        finalValue === expectedValueBeforeFix,
+        `Assertion Failed: Expected value to be "${expectedValueBeforeFix}", but it was "${finalValue}".`
+    );
+
+    if (finalValue === expectedValueBeforeFix) {
+        console.log(`%cTest Passed (Bug Reproduced): Input was correctly truncated to "${expectedValueBeforeFix}".`, "color: green;");
+    } else {
+        console.error(`%cTest Failed (Bug Not Reproduced as Expected): The value was not the expected "${expectedValueBeforeFix}". This might mean the bug is already fixed or the test is flawed.`, "color: red;");
+    }
+    console.log("--- Test Complete ---");
+}
+
+// Automatically run the test
+runValidationTest();

--- a/tests/verification_test.js
+++ b/tests/verification_test.js
@@ -1,0 +1,54 @@
+/**
+ * To run this test:
+ * 1. Open the index.html file in a web browser.
+ * 2. Open the browser's developer console.
+ * 3. Copy and paste the content of this file into the console and press Enter.
+ * 4. The test function `runVerificationTest()` will be executed.
+ * 5. Observe the console output for the test result.
+ *
+ * This test verifies that the input validation logic has been fixed.
+ * It simulates a user typing "12.3.4" into the 'Bill Amount' field.
+ *
+ * The expected behavior after the fix is that the input's value
+ * will be correctly converted to "12.34". The test will pass if this happens.
+ */
+function runVerificationTest() {
+    console.log("--- Running Bug Verification Test ---");
+
+    // 1. Get the input element to test
+    const billAmountInput = document.getElementById('billAmount');
+    if (!billAmountInput) {
+        console.error("Test failed: Could not find the 'billAmount' input element.");
+        return;
+    }
+
+    // 2. Set a value with multiple decimal points
+    billAmountInput.value = "12.3.4";
+    console.log(`Set input value to: "${billAmountInput.value}"`);
+
+    // 3. Dispatch an 'input' event to trigger the validation logic
+    const inputEvent = new Event('input', { bubbles: true });
+    billAmountInput.dispatchEvent(inputEvent);
+    console.log("Dispatched 'input' event.");
+
+    // 4. Check the resulting value
+    const finalValue = billAmountInput.value;
+    console.log(`Final input value is: "${finalValue}"`);
+
+    // 5. Assert the correct behavior
+    const expectedValueAfterFix = "12.34";
+    console.assert(
+        finalValue === expectedValueAfterFix,
+        `Assertion Failed: Expected value to be "${expectedValueAfterFix}", but it was "${finalValue}".`
+    );
+
+    if (finalValue === expectedValueAfterFix) {
+        console.log(`%cTest Passed (Bug Verified as Fixed): Input was correctly converted to "${expectedValueAfterFix}".`, "color: green;");
+    } else {
+        console.error(`%cTest Failed (Bug Still Present): The value was not the expected "${expectedValueAfterFix}".`, "color: red;");
+    }
+    console.log("--- Test Complete ---");
+}
+
+// Automatically run the test
+runVerificationTest();


### PR DESCRIPTION
The previous implementation used inconsistent and incorrect regular expressions for validating decimal inputs across different calculators. This could lead to user input being silently truncated if it contained multiple decimal points (e.g., "12.3.4" would become "12.3").

This commit refactors the code to use a single, robust `validateDecimalInput` function for all decimal fields. This function correctly handles multiple decimal points by sanitizing the input (e.g., "12.3.4" correctly becomes "12.34").

This change resolves the bug and makes the validation logic consistent and easier to maintain.